### PR TITLE
adjusted backend mock testing to pass

### DIFF
--- a/term-project/back/src/main/java/edu/brown/cs/student/main/CoordinateData/CoordinateMockedData.java
+++ b/term-project/back/src/main/java/edu/brown/cs/student/main/CoordinateData/CoordinateMockedData.java
@@ -20,8 +20,7 @@ public class CoordinateMockedData implements CoordinateData {
     public CoordinateApiResponse getCoordinateData(String address) {
         CoordinateApiResponse mockedConversionObject = new CoordinateApiResponse();
 
-        if (address.equals("1%20INTERNATIONAL%20PL%20STE%20P110%20BOSTON%20MA")) {
-            System.out.println("FOUND ADDRESS 1");
+        if (address.equals("1 INTERNATIONAL PL STE P110 BOSTON MA")) {
             mockedConversionObject.status = "OK";
             ArrayList<CoordinateApiResponse.Result> allResults = new ArrayList<>();
 
@@ -38,9 +37,7 @@ public class CoordinateMockedData implements CoordinateData {
             allResults.add(result);
             mockedConversionObject.result = allResults;
 
-        } else if (address.equals("4%20DEVONSHIRE%20ST%20BOSTON%20MA")){
-            System.out.println("FOUND ADDRESS 2");
-
+        } else if (address.equals("4 DEVONSHIRE ST BOSTON MA")){
             mockedConversionObject.status = "OK";
             ArrayList<CoordinateApiResponse.Result> allResults = new ArrayList<>();
 
@@ -56,8 +53,55 @@ public class CoordinateMockedData implements CoordinateData {
 
             allResults.add(result);
             mockedConversionObject.result = allResults;
-        } else {
-            mockedConversionObject.error_message = "This address was not found in mocked data.";
+        } else if (address.equals("150 Morrissey Blvd, Boston, MA 02125")) {
+            mockedConversionObject.status = "OK";
+            ArrayList<CoordinateApiResponse.Result> allResults = new ArrayList<>();
+
+            CoordinateApiResponse.Result result = new CoordinateApiResponse.Result();
+            result.formatted_address = "150 Morrissey Boulevard, Dorchester, Dorchester 02125, United States";
+
+            CoordinateApiResponse.Geometry geometry = new CoordinateApiResponse.Geometry();
+            CoordinateApiResponse.Location location = new CoordinateApiResponse.Location();
+            location.lat = 42.315949849999996;
+            location.lng = -71.04466860363372;
+            geometry.location = location;
+            result.geometry = geometry;
+
+            allResults.add(result);
+            mockedConversionObject.result = allResults;
+        } else if (address.equals("INVALID_ADDRESS")){
+            mockedConversionObject.status = "OK";
+            ArrayList<CoordinateApiResponse.Result> allResults = new ArrayList<>();
+
+            CoordinateApiResponse.Result result = new CoordinateApiResponse.Result();
+            result.formatted_address = "";
+
+            CoordinateApiResponse.Geometry geometry = new CoordinateApiResponse.Geometry();
+            CoordinateApiResponse.Location location = new CoordinateApiResponse.Location();
+            location.lat = 0.0;
+            location.lng = 0.0;
+            geometry.location = location;
+            result.geometry = geometry;
+
+            allResults.add(result);
+            mockedConversionObject.result = allResults;
+        } else { // address is not mocked
+            mockedConversionObject.status = "NOT_MOCKED";
+            ArrayList<CoordinateApiResponse.Result> allResults = new ArrayList<>();
+
+            CoordinateApiResponse.Result result = new CoordinateApiResponse.Result();
+            result.formatted_address = "";
+
+            CoordinateApiResponse.Geometry geometry = new CoordinateApiResponse.Geometry();
+            CoordinateApiResponse.Location location = new CoordinateApiResponse.Location();
+            location.lat = 0.0;
+            location.lng = 0.0;
+            geometry.location = location;
+            result.geometry = geometry;
+
+            allResults.add(result);
+            mockedConversionObject.result = allResults;
+            mockedConversionObject.error_message = "Address coordinates are unmocked.";
         }
         return mockedConversionObject;
     }

--- a/term-project/back/src/main/java/edu/brown/cs/student/main/DistanceData/DistanceMockedData.java
+++ b/term-project/back/src/main/java/edu/brown/cs/student/main/DistanceData/DistanceMockedData.java
@@ -19,8 +19,7 @@ public class DistanceMockedData implements DistanceData {
         DistanceApiResponse mockedFilteredObject = new DistanceApiResponse();
 
         // normal response
-        if (selectedLat.equals("42.3540901") && selectedLong.equals("-71.07004020962789") && workLat.equals("42.3556559") && workLong.equals("-71.0521838")){
-            System.out.println("FOUND MOCKED DATA");
+        if (selectedLat.equals("42.3540901") && selectedLong.equals("-71.07004020962789") && workLat.equals("42.3556559") && workLong.equals("-71.0521838")) {
             ArrayList<String> destinationAddresses = new ArrayList<>();
             destinationAddresses.add("Christian Science Center- Belvidere/ Dalton, Boston, MA 02110, USA");
             mockedFilteredObject.destination_addresses = destinationAddresses;
@@ -37,6 +36,7 @@ public class DistanceMockedData implements DistanceData {
             distance.text = "1.3 mi";
             DistanceApiResponse.Duration duration = new DistanceApiResponse.Duration();
             duration.text = "9 mins";
+            element.duration = duration;
             element.distance = distance;
             element.origin = "42.3540901,-71.07004020962789";
             element.destination = "42.3556559,-71.0521838";
@@ -44,8 +44,73 @@ public class DistanceMockedData implements DistanceData {
 
             row.elements = allElements;
             allRows.add(row);
-            mockedFilteredObject.rows.add(row);
+            mockedFilteredObject.rows = allRows;
             mockedFilteredObject.status = "OK";
+
+            // selected address is invalid
+        } else if (selectedLat.equals("0.0") && selectedLong.equals("0.0") && workLat.equals("42.3556559") && workLong.equals("-71.0521838")){
+            ArrayList<String> destinationAddresses = new ArrayList<>();
+            destinationAddresses.add("Christian Science Center- Belvidere/ Dalton, Boston, MA 02110, USA");
+            mockedFilteredObject.destination_addresses = destinationAddresses;
+            ArrayList<String> originAddresses = new ArrayList<>();
+            originAddresses.add("");
+            mockedFilteredObject.origin_addresses = originAddresses;
+
+            ArrayList<DistanceApiResponse.Row> allRows = new ArrayList<>();
+            DistanceApiResponse.Row row = new DistanceApiResponse.Row();
+            ArrayList<DistanceApiResponse.Element> allElements = new ArrayList<>();
+            DistanceApiResponse.Element element = new DistanceApiResponse.Element();
+            allElements.add(element);
+            element.duration = null;
+            element.distance = null;
+            element.origin = "0.0,0.0";
+            element.destination = "42.3556559,-71.0521838";
+            element.status = "ZERO_RESULTS";
+
+            row.elements = allElements;
+            allRows.add(row);
+            mockedFilteredObject.rows = allRows;
+            mockedFilteredObject.status = "OK";
+        } else if (selectedLat.equals("42.3540901") && selectedLong.equals("-71.07004020962789") && workLat.equals("0.0") && workLong.equals("0.0")) {
+            ArrayList<String> destinationAddresses = new ArrayList<>();
+            destinationAddresses.add("");
+            mockedFilteredObject.destination_addresses = destinationAddresses;
+            ArrayList<String> originAddresses = new ArrayList<>();
+            originAddresses.add("Public Garden, Boston, MA 02116, United States");
+            mockedFilteredObject.origin_addresses = originAddresses;
+
+            ArrayList<DistanceApiResponse.Row> allRows = new ArrayList<>();
+            DistanceApiResponse.Row row = new DistanceApiResponse.Row();
+            ArrayList<DistanceApiResponse.Element> allElements = new ArrayList<>();
+            DistanceApiResponse.Element element = new DistanceApiResponse.Element();
+            allElements.add(element);
+            element.duration = null;
+            element.distance = null;
+            element.origin = "42.3540901,-71.07004020962789";
+            element.destination = "0.0,0.0";
+            element.status = "ZERO_RESULTS";
+
+            row.elements = allElements;
+            allRows.add(row);
+            mockedFilteredObject.rows = allRows;
+            mockedFilteredObject.status = "OK";
+        } else {
+            ArrayList<String> destinationAddresses = new ArrayList<>();
+            destinationAddresses.add("");
+            mockedFilteredObject.destination_addresses = destinationAddresses;
+            ArrayList<String> originAddresses = new ArrayList<>();
+            originAddresses.add("");
+            mockedFilteredObject.origin_addresses = originAddresses;
+
+            ArrayList<DistanceApiResponse.Row> allRows = new ArrayList<>();
+            DistanceApiResponse.Row row = new DistanceApiResponse.Row();
+            ArrayList<DistanceApiResponse.Element> allElements = new ArrayList<>();
+            DistanceApiResponse.Element element = new DistanceApiResponse.Element();
+            allElements.add(element);
+            row.elements = allElements;
+            allRows.add(row);
+            mockedFilteredObject.rows = allRows;
+            mockedFilteredObject.status = "NOT_MOCKED";
         }
 
         return mockedFilteredObject;

--- a/term-project/back/src/main/java/edu/brown/cs/student/main/DistanceHandler/FilterHandler.java
+++ b/term-project/back/src/main/java/edu/brown/cs/student/main/DistanceHandler/FilterHandler.java
@@ -47,7 +47,7 @@ public class FilterHandler implements Route {
       String selectedLat = null;
       String selectedLong = null;
       String workLat = null;
-      String workLong = null; // TODO: change to empty string?
+      String workLong = null;
       if (request.queryParams("address") == null || request.queryParams("address").equals("")) {
         responseMap.put("result", "error_bad_request");
         responseMap.put("missing", "selected address query parameter");
@@ -190,7 +190,7 @@ public class FilterHandler implements Route {
               workLong);
 
       if (res != null) {
-//        if (res.status 1)
+//        if (res.status != null){
         responseMap.put("status", res.status);
         if ("OK".equals(res.status)) {
           // Process the parsed data, e.g., print the duration and distance

--- a/term-project/back/src/test/java/edu/brown/cs/student/FilterTests/FilterMockedTest.java
+++ b/term-project/back/src/test/java/edu/brown/cs/student/FilterTests/FilterMockedTest.java
@@ -80,18 +80,167 @@ public class FilterMockedTest {
         assertEquals(200, loadConnection.getResponseCode());
         MockedFilterResponse body =
                 filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
-        System.out.println("body" + body.status);
-        assertEquals("42.3560387", body.converted_work_latitude);
-        assertEquals("-71.052138", body.converted_work_longitude);
-        assertEquals("42.3587053", body.converted_selected_latitude);
-        assertEquals("-71.0567859", body.converted_selected_longitude);
-        assertEquals("4 Devonshire St, Boston, MA 02109, USA", body.formatted_address);
-        assertEquals("1 International Pl p110, Boston, MA 02110, USA", body.formatted_work_address);
-        assertEquals("42.3560387,-71.052138", body.destination);
-        assertEquals("42.3587053,-71.0567859", body.origin);
-        assertEquals("3 mins", body.duration);
-        assertEquals("200", body.status);
-        assertEquals("0.4 mi", body.distance);
+        assertEquals("42.3556559", body.converted_work_latitude);
+        assertEquals("-71.0521838", body.converted_work_longitude);
+        assertEquals("42.3540901", body.converted_selected_latitude);
+        assertEquals("-71.07004020962789", body.converted_selected_longitude);
+        assertEquals("4 Charles Street, Boston 02116, United States", body.formatted_address);
+        assertEquals("1 International Place, Downtown Boston, Boston 02110, United States", body.formatted_work_address);
+        assertEquals("42.3556559,-71.0521838", body.destination);
+        assertEquals("42.3540901,-71.07004020962789", body.origin);
+        assertEquals("9 mins", body.duration);
+        assertEquals("OK", body.status);
+        assertEquals("1.3 mi", body.distance);
+
+        loadConnection.disconnect();
+    }
+
+
+    /**
+     * Testing the filter handler with a missing selected address input
+     *
+     * @throws IOException for connection issues.
+     */
+    @Test
+    public void testFilterMissingSelected() throws IOException {
+        // Set up the request, make the request
+        HttpURLConnection loadConnection = tryRequest("filter?workAddress=1%20INTERNATIONAL%20PL%20STE%20P110%20BOSTON%20MA&address=");
+        // Get the expected response: a success
+        assertEquals(200, loadConnection.getResponseCode());
+        MockedFilterResponse body =
+                filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
+        assertEquals(null, body.converted_work_latitude);
+        assertEquals(null, body.converted_work_longitude);
+        assertEquals(null, body.converted_selected_latitude);
+        assertEquals(null, body.converted_selected_longitude);
+        assertEquals(null, body.formatted_address);
+        assertEquals(null, body.formatted_work_address);
+        assertEquals(null, body.destination);
+        assertEquals(null, body.origin);
+        assertEquals("error_bad_request", body.result);
+        assertEquals("selected address query parameter", body.missing);
+        assertEquals("Invalid request: missing selected address query parameter", body.error);
+        assertEquals(null, body.duration);
+        assertEquals(null, body.status);
+        assertEquals(null, body.distance);
+
+        loadConnection.disconnect();
+    }
+
+    /**
+     * Testing the filter handler with an invalid selected address input
+     *
+     * @throws IOException for connection issues.
+     */
+    @Test
+    public void testFilterInvalidSelected() throws IOException {
+        // Set up the request, make the request
+        HttpURLConnection loadConnection = tryRequest("filter?workAddress=1%20INTERNATIONAL%20PL%20STE%20P110%20BOSTON%20MA&address=INVALID_ADDRESS");
+        // Get the expected response: a success
+        assertEquals(200, loadConnection.getResponseCode());
+        MockedFilterResponse body =
+                filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
+        assertEquals("42.3556559", body.converted_work_latitude);
+        assertEquals("-71.0521838", body.converted_work_longitude);
+        assertEquals("0.0", body.converted_selected_latitude);
+        assertEquals("0.0", body.converted_selected_longitude);
+        assertEquals("", body.formatted_address);
+        assertEquals("1 International Place, Downtown Boston, Boston 02110, United States", body.formatted_work_address);
+        assertEquals("42.3556559,-71.0521838", body.destination);
+        assertEquals("0.0,0.0", body.origin);
+        assertEquals(null, body.duration);
+        assertEquals(null, body.distance);
+        assertEquals("ZERO_RESULTS", body.status);
+        assertEquals("No route could be found between the origin and destination.", body.error);
+
+        loadConnection.disconnect();
+    }
+
+    /**
+     * Testing the filter handler with a missing work address input
+     *
+     * @throws IOException for connection issues.
+     */
+    @Test
+    public void testFilterMissingWork() throws IOException {
+        // Set up the request, make the request
+        HttpURLConnection loadConnection = tryRequest("filter?workAddress=&address=4%20DEVONSHIRE%20ST%20BOSTON%20MA");
+        // Get the expected response: a success
+        assertEquals(200, loadConnection.getResponseCode());
+        MockedFilterResponse body =
+                filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
+        assertEquals(null, body.converted_work_latitude);
+        assertEquals(null, body.converted_work_longitude);
+        assertEquals("42.3540901", body.converted_selected_latitude);
+        assertEquals("-71.07004020962789", body.converted_selected_longitude);
+        assertEquals("4 Charles Street, Boston 02116, United States", body.formatted_address);
+        assertEquals(null, body.formatted_work_address);
+        assertEquals(null, body.destination);
+        assertEquals(null, body.origin);
+        assertEquals("error_bad_request", body.result);
+        assertEquals("work address query parameter", body.missing);
+        assertEquals("Invalid request: missing work address query parameter", body.error);
+        assertEquals(null, body.duration);
+        assertEquals(null, body.status);
+        assertEquals(null, body.distance);
+
+        loadConnection.disconnect();
+    }
+
+    /**
+     * Testing the filter handler with an invalid work address input
+     *
+     * @throws IOException for connection issues.
+     */
+    @Test
+    public void testFilterInvalidWork() throws IOException {
+        // Set up the request, make the request
+        HttpURLConnection loadConnection = tryRequest("filter?workAddress=INVALID_ADDRESS&address=4%20DEVONSHIRE%20ST%20BOSTON%20MA");
+        // Get the expected response: a success
+        assertEquals(200, loadConnection.getResponseCode());
+        MockedFilterResponse body =
+                filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
+        assertEquals("0.0", body.converted_work_latitude);
+        assertEquals("0.0", body.converted_work_longitude);
+        assertEquals("42.3540901", body.converted_selected_latitude);
+        assertEquals("-71.07004020962789", body.converted_selected_longitude);
+        assertEquals("4 Charles Street, Boston 02116, United States", body.formatted_address);
+        assertEquals("", body.formatted_work_address);
+        assertEquals("0.0,0.0", body.destination);
+        assertEquals("42.3540901,-71.07004020962789", body.origin);
+        assertEquals(null, body.duration);
+        assertEquals(null, body.distance);
+        assertEquals("ZERO_RESULTS", body.status);
+        assertEquals("No route could be found between the origin and destination.", body.error);
+
+        loadConnection.disconnect();
+    }
+
+    /**
+     * Testing the filter handler with unmocked data inputs
+     *
+     * @throws IOException for connection issues.
+     */
+    @Test
+    public void testFilterUnmocked() throws IOException {
+        // Set up the request, make the request
+        HttpURLConnection loadConnection = tryRequest("filter?workAddress=notMocked&address=notMocked");
+        // Get the expected response: a success
+        assertEquals(200, loadConnection.getResponseCode());
+        MockedFilterResponse body =
+                filterAdapter.fromJson(new Buffer().readFrom(loadConnection.getInputStream()));
+        assertEquals(null, body.converted_work_latitude);
+        assertEquals(null, body.converted_work_longitude);
+        assertEquals(null, body.converted_selected_latitude);
+        assertEquals(null, body.converted_selected_longitude);
+        assertEquals(null, body.formatted_address);
+        assertEquals(null, body.formatted_work_address);
+        assertEquals(null, body.destination);
+        assertEquals(null, body.origin);
+        assertEquals(null, body.duration);
+        assertEquals(null, body.distance);
+        assertEquals(null, body.status);
+        assertEquals("Address coordinates are unmocked.", body.error);
 
         loadConnection.disconnect();
     }
@@ -107,7 +256,6 @@ public class FilterMockedTest {
     private HttpURLConnection tryRequest(String apiCall) throws IOException {
         // Configure the connection (but don't actually send a request yet)
         URL requestURL = new URL("http://localhost:" + Spark.port() + "/" + apiCall);
-        System.out.println("sending: " + requestURL);
         HttpURLConnection clientConnection = (HttpURLConnection) requestURL.openConnection();
         // The request body contains a Json object
         clientConnection.setRequestProperty("Content-Type", "application/json");

--- a/term-project/front/src/components/Listings.tsx
+++ b/term-project/front/src/components/Listings.tsx
@@ -32,7 +32,6 @@ interface Listing {
   imgUrl: string;
   price: number;
   title: string;
-  // TODO: add date posted on postNewListing?
   latitude?: number;
   longitude?: number;
   distance?: number;


### PR DESCRIPTION
Adjusted CoordinateMockedData to use spaces instead of %20 to get tests to run

Gracefully handled errors on FilterHandler using mocked data
- [x] Valid selected address and work address input
- [x] Missing selected address input
- [x] Invalid selected address input
- [x] Missing work address input
- [x] Invalid work address input
- [x] Unmocked selected address and work address inputs